### PR TITLE
seo(llm): optimize site for LLM/AI search discoverability

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,78 @@
+---
+layout: null
+permalink: /404.html
+title: "Page Not Found"
+seo_title: "404 — Page Not Found | Rombo AI"
+description: "The page you are looking for was not found on rombo.ai. Browse our products, use cases or blog to keep exploring."
+robots: "noindex, follow"
+sitemap: false
+lang: en
+---
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+{% include header.html %}
+<body>
+
+{% include menu.html %}
+
+<main id="main-content" tabindex="-1">
+  <section class="container-fluid py-5" style="min-height: 70vh; display: flex; align-items: center; justify-content: center; background:#FAFAFA;">
+    <div class="container custom_container text-center py-5">
+      <p class="fw-bold text-uppercase mb-2" style="font-size: 14px; color:#FE900F; letter-spacing:.06em;">Error 404</p>
+      <h1 class="fw-bold text-dark" style="font-size: 48px;">This page does not exist</h1>
+      <p class="text-dark mt-3 mx-auto" style="max-width: 65ch;">
+        The URL you requested was not found on rombo.ai. It may have been moved, renamed, or never existed.
+      </p>
+
+      <div class="row g-3 justify-content-center mt-4" style="max-width: 900px; margin: 0 auto;">
+        <div class="col-12 col-md-6 col-lg-4">
+          <a href="{{ '/' | relative_url }}" class="d-block p-4 border rounded-4 bg-white text-decoration-none h-100">
+            <div class="fw-bold text-dark">Home</div>
+            <div class="text-muted" style="font-size: 14px;">Back to the homepage</div>
+          </a>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <a href="{{ '/product/' | relative_url }}" class="d-block p-4 border rounded-4 bg-white text-decoration-none h-100">
+            <div class="fw-bold text-dark">Material Intelligence Platform</div>
+            <div class="text-muted" style="font-size: 14px;">NMR AI Analyzer and AutoML Framework</div>
+          </a>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <a href="{{ '/use-cases/' | relative_url }}" class="d-block p-4 border rounded-4 bg-white text-decoration-none h-100">
+            <div class="fw-bold text-dark">Use cases</div>
+            <div class="text-muted" style="font-size: 14px;">Crude oil and transformer mineral oil analysis</div>
+          </a>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <a href="{{ '/blog/' | relative_url }}" class="d-block p-4 border rounded-4 bg-white text-decoration-none h-100">
+            <div class="fw-bold text-dark">Blog</div>
+            <div class="text-muted" style="font-size: 14px;">AI, NMR, and materials analysis</div>
+          </a>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <a href="{{ '/about/' | relative_url }}" class="d-block p-4 border rounded-4 bg-white text-decoration-none h-100">
+            <div class="fw-bold text-dark">About Rombo AI</div>
+            <div class="text-muted" style="font-size: 14px;">Team, mission and values</div>
+          </a>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <a href="{{ '/contact/' | relative_url }}" class="d-block p-4 border rounded-4 bg-white text-decoration-none h-100">
+            <div class="fw-bold text-dark">Contact</div>
+            <div class="text-muted" style="font-size: 14px;">Book a demo or get in touch</div>
+          </a>
+        </div>
+      </div>
+
+      <p class="text-muted mt-5" style="font-size: 13px;">
+        If you arrived here from a link, please <a href="{{ '/contact/' | relative_url }}">let us know</a> so we can fix it.
+      </p>
+    </div>
+  </section>
+
+  {% include footer.html %}
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous" defer></script>
+<script defer src="{{ site.baseurl }}/js/main.js"></script>
+</body>
+</html>

--- a/_authors/andrea-zanda.md
+++ b/_authors/andrea-zanda.md
@@ -1,0 +1,15 @@
+---
+slug: andrea-zanda
+name: "Andrea Zanda"
+job_title: "CEO & Co-founder"
+short_role: "CEO"
+bio: "Andrea Zanda is co-founder and CEO of Rombo AI. He works at the intersection of machine learning, software engineering, and spectroscopy, leading the development of AI products that transform industrial material analysis."
+image: "/img/team/andrea-zanda.jpg"
+linkedin: "https://www.linkedin.com/in/andreazanda/"
+expertise:
+  - "Machine learning"
+  - "Foundation models"
+  - "Product strategy"
+seo_title: "Andrea Zanda — CEO & Co-founder | Rombo AI"
+description: "Andrea Zanda, CEO and co-founder of Rombo AI. Background in machine learning and software engineering applied to spectral analysis and industrial AI."
+---

--- a/_authors/carmine-mattia.md
+++ b/_authors/carmine-mattia.md
@@ -1,0 +1,15 @@
+---
+slug: carmine-mattia
+name: "Carmine Mattia"
+job_title: "CTO & Co-founder"
+short_role: "CTO"
+bio: "Carmine Mattia is co-founder and CTO of Rombo AI. He leads the engineering and AI architecture behind Rombo AI's foundation model for quantitative NMR and the Material Intelligence Platform."
+image: "/img/team/carmine-mattia.jpg"
+linkedin: ""
+expertise:
+  - "AI architecture"
+  - "Deep learning"
+  - "Quantitative NMR"
+seo_title: "Carmine Mattia — CTO & Co-founder | Rombo AI"
+description: "Carmine Mattia, CTO and co-founder of Rombo AI. Leads engineering and AI architecture for the foundation model for quantitative NMR."
+---

--- a/_authors/silvia-bongiovanni.md
+++ b/_authors/silvia-bongiovanni.md
@@ -1,0 +1,15 @@
+---
+slug: silvia-bongiovanni
+name: "Silvia Bongiovanni"
+job_title: "Marketing & Communications"
+short_role: "Marketing"
+bio: "Silvia Bongiovanni leads marketing and communications at Rombo AI, translating complex AI and spectroscopy topics into clear value propositions for industrial customers."
+image: "/img/team/silvia-bongiovanni.jpg"
+linkedin: ""
+expertise:
+  - "B2B marketing"
+  - "Technical communications"
+  - "Industrial AI positioning"
+seo_title: "Silvia Bongiovanni — Marketing & Communications | Rombo AI"
+description: "Silvia Bongiovanni, marketing and communications at Rombo AI."
+---

--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,42 @@ contact_email: "contact@rombo.ai"
 contact_phone: "+39 352 064 8081"
 contact_phone_raw: "+393520648081"
 
+# Organization (single source of truth for JSON-LD + footer + meta)
+organization:
+  legal_name: "Rombo AI S.r.l."
+  founding_date: "2023"
+  founding_location: "Cagliari, Italy"
+  address:
+    street: ""              # TODO: compile when available
+    locality: "Cagliari"
+    region: "Sardinia"
+    postal_code: ""         # TODO: compile when available
+    country: "IT"
+  geo:
+    latitude: 39.2293491
+    longitude: 9.073249
+  area_served:
+    - "EU"
+    - "Worldwide"
+  knows_about:
+    - "Low-field NMR"
+    - "Quantitative NMR"
+    - "Benchtop NMR"
+    - "Spectral analysis"
+    - "Machine learning"
+    - "Deep learning"
+    - "Foundation models"
+    - "Crude oil analysis"
+    - "Transformer mineral oil analysis"
+    - "Materials chemistry"
+    - "AutoML"
+  same_as:
+    - "https://www.linkedin.com/company/rombo-ai/"
+  industry:
+    - "Artificial Intelligence"
+    - "Spectroscopy"
+    - "Industrial Analytics"
+
 # Default CTA (fallback). Engage CTAs will reuse the Home hero CTA when available.
 cta_label_left: "Contact"
 cta_label_right: "now"
@@ -21,6 +57,8 @@ markdown: kramdown
 # Kramdown (2.x) needs the GFM parser gem for GitHub-flavored markdown features.
 kramdown:
   input: GFM
+  auto_ids: true
+  toc_levels: 2..4
 # Engage Section
 engage_main_title: "DISCOVER WHAT AI-DRIVEN SPECTRAL ANALYSIS CAN DO FOR YOU"
 engage_sub_title: "Contact Us"
@@ -31,6 +69,21 @@ permalink: :title/
 collections:
   pages:
     output: true
+  authors:
+    output: true
+    permalink: /author/:path/
+
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: article
+  - scope:
+      path: ""
+      type: authors
+    values:
+      layout: author
 sass:
   sass_dir: _sass
   style:    compressed

--- a/_includes/author_resolve.html
+++ b/_includes/author_resolve.html
@@ -1,0 +1,39 @@
+{%- comment -%}
+  Resolves a post author string (e.g. "Andrea Zanda" or "Carmine Mattia, CTO")
+  to the matching entry in the _authors collection.
+
+  Usage:
+    {% assign author_obj = nil %}
+    {% include author_resolve.html author=post.author %}
+    {% if author_obj %} ... {% endif %}
+
+  Sets:
+    - author_obj: matching _authors document (or nil)
+    - author_name_normalized: canonical name (page.name) or stripped input
+{%- endcomment -%}
+
+{%- assign _raw = include.author | default: "" | strip -%}
+{%- assign _first = _raw | split: "," | first | strip -%}
+{%- assign author_name_normalized = _first -%}
+{%- assign author_obj = nil -%}
+
+{%- for a in site.authors -%}
+  {%- if a.name == _first -%}
+    {%- assign author_obj = a -%}
+    {%- assign author_name_normalized = a.name -%}
+    {%- break -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- if author_obj == nil -%}
+  {%- comment -%} Fallback: match on first token (e.g. "Andrea") {%- endcomment -%}
+  {%- assign _first_token = _first | split: " " | first -%}
+  {%- for a in site.authors -%}
+    {%- assign a_first = a.name | split: " " | first -%}
+    {%- if a_first == _first_token -%}
+      {%- assign author_obj = a -%}
+      {%- assign author_name_normalized = a.name -%}
+      {%- break -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif -%}

--- a/_includes/blog_articles.html
+++ b/_includes/blog_articles.html
@@ -1,32 +1,32 @@
 <!-- Articles Section -->
-<section class="container-fluid bg-white">
+<section class="container-fluid bg-white" aria-labelledby="blog-list-heading">
     <div class="container custom_container">
         <div class="row py-5 px-5 text-left justify-content-center">
-            <h2 class="z-1 fw-bold text-dark" style="font-size: 42px; line-height: 46.2px;">What to read next</h2>
+            <h2 id="blog-list-heading" class="z-1 fw-bold text-dark" style="font-size: 42px; line-height: 46.2px;">What to read next</h2>
         </div>
 
         <div class="row">
             <div class="col-12">
                 <!-- Grid of Posts -->
-                <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+                <ul class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 list-unstyled">
                     {% for post in site.posts %}
-                    <div class="col mb-4 " style="min-width: 300px;">
-                        <div class="card h-100">
+                    <li class="col mb-4 " style="min-width: 300px;">
+                        <article class="card h-100">
                             <a href="{{ site.baseurl }}{{ post.url }}">
                                 <img class="post-image"
                                      src="{{ post.image | relative_url }}"
                                      alt="{{ post.image_alt | default: post.title }}"
-                                     width="600" height="400" loading="lazy">
+                                     width="600" height="400" loading="lazy" decoding="async">
                                 <div class="post-content">
-                                    <div class="date">{{ post.date | date: "%b %d, %Y" }}</div>
-                                    <div class="title">{{ post.title }}</div>
-                                    <p class="description">{{ post.excerpt | truncate: 100 }}</p>
+                                    <time class="date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %d, %Y" }}</time>
+                                    <h3 class="title" style="font-size:18px;">{{ post.title }}</h3>
+                                    <p class="description">{{ post.excerpt | strip_html | truncate: 140 }}</p>
                                 </div>
                             </a>
-                        </div>
-                    </div>
+                        </article>
+                    </li>
                     {% endfor %}
-                </div>
+                </ul>
             </div>
         </div>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,11 +11,51 @@
 
       gtag('js', new Date());
 
+      // ── AI referral detection ────────────────────────────────────────────
+      // Classifies the visit source against known LLM assistants so we can
+      // measure traffic from AI surfaces in GA4 (Reports → Acquisition →
+      // Channel groupings → custom "AI Assistants" group).
+      var __ai_source = (function () {
+        try {
+          var ref = (document.referrer || '').toLowerCase();
+          var qs  = (location.search || '').toLowerCase();
+          var ai_hosts = [
+            'chatgpt.com', 'chat.openai.com', 'openai.com',
+            'perplexity.ai', 'www.perplexity.ai',
+            'gemini.google.com', 'bard.google.com',
+            'copilot.microsoft.com', 'bing.com/chat',
+            'you.com', 'claude.ai', 'anthropic.com',
+            'duckduckgo.com/aichat',
+            'meta.ai', 'mistral.ai'
+          ];
+          for (var i = 0; i < ai_hosts.length; i++) {
+            if (ref.indexOf(ai_hosts[i]) !== -1) return ai_hosts[i];
+          }
+          if (qs.indexOf('utm_source=chatgpt') !== -1)   return 'chatgpt.com';
+          if (qs.indexOf('utm_source=perplexity') !== -1) return 'perplexity.ai';
+          if (qs.indexOf('utm_source=copilot') !== -1)   return 'copilot.microsoft.com';
+          if (qs.indexOf('utm_source=gemini') !== -1)    return 'gemini.google.com';
+          if (qs.indexOf('utm_source=claude') !== -1)    return 'claude.ai';
+          return null;
+        } catch (e) { return null; }
+      })();
+
       // Google Analytics 4
       gtag('config', 'G-HNBF12R3GQ', {
         'anonymize_ip': true,
         'cookie_flags': 'SameSite=None;Secure'
       });
+
+      // Custom event + user properties for AI referrals (visible in GA4
+      // explorations and used to build a custom channel grouping).
+      if (__ai_source) {
+        gtag('set', 'user_properties', { ai_referrer: __ai_source });
+        gtag('event', 'ai_assistant_referral', {
+          ai_source: __ai_source,
+          page_location: location.href,
+          page_referrer: document.referrer || ''
+        });
+      }
 
       // Google Ads conversion tracking
       // Note: Browser cross-origin frame warnings may appear but are harmless - Google uses
@@ -76,27 +116,62 @@
     {%- assign canonical_url = page.url | absolute_url -%}
     {%- assign og_image = page.og_image | default: page.image | default: site.og_image -%}
     {%- assign og_image = og_image | absolute_url -%}
-    {%- assign robots = page.robots | default: "index,follow" -%}
+    {%- comment -%}
+      Default robots directive: max snippet + large image preview unlock rich
+      previews for AI surfaces (Google AI Overviews, ChatGPT Search, Copilot).
+      Pages can override via `robots:` in front matter.
+    {%- endcomment -%}
+    {%- assign robots = page.robots | default: "index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" -%}
+    {%- assign page_modified = page.last_modified_at | default: page.dateModified | default: page.date -%}
 
     <title>{{ seo_title }}{% unless seo_title contains site.title %} | {{ site.title }}{% endunless %}</title>
     <meta name="description" content="{{ meta_description }}">
     <meta name="robots" content="{{ robots }}">
+    <meta name="googlebot" content="{{ robots }}">
+    <meta name="bingbot" content="{{ robots }}">
     <link rel="canonical" href="{{ canonical_url }}">
+
+    {%- if page.layout == "article" and page.author %}
+    <meta name="author" content="{{ page.author }}">
+    {%- endif %}
 
     <!-- Open Graph -->
     <meta property="og:site_name" content="{{ site.title }}">
     <meta property="og:locale" content="{{ site.locale | default: 'en_US' }}">
-    <meta property="og:type" content="{% if page.layout == 'article' %}article{% else %}website{% endif %}">
+    <meta property="og:type" content="{% if page.layout == 'article' %}article{% elsif page.layout == 'author' %}profile{% else %}website{% endif %}">
     <meta property="og:title" content="{{ seo_title }}">
     <meta property="og:description" content="{{ meta_description }}">
     <meta property="og:url" content="{{ canonical_url }}">
     <meta property="og:image" content="{{ og_image }}">
+    <meta property="og:image:alt" content="{{ page.og_image_alt | default: seo_title }}">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    {%- if page.layout == "article" %}
+    <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
+    {%- if page_modified and page_modified != page.date %}
+    <meta property="article:modified_time" content="{{ page_modified | date_to_xmlschema }}">
+    {%- endif %}
+    {%- if page.author %}
+    <meta property="article:author" content="{{ page.author }}">
+    {%- endif %}
+    {%- if page.tags %}
+    {%- for tag in page.tags %}
+    <meta property="article:tag" content="{{ tag }}">
+    {%- endfor %}
+    {%- endif %}
+    {%- if page.categories %}
+    {%- for cat in page.categories %}
+    <meta property="article:section" content="{{ cat }}">
+    {%- endfor %}
+    {%- endif %}
+    {%- endif %}
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ seo_title }}">
     <meta name="twitter:description" content="{{ meta_description }}">
     <meta name="twitter:image" content="{{ og_image }}">
+    <meta name="twitter:image:alt" content="{{ page.og_image_alt | default: seo_title }}">
 
     <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/img/apple-touch-icon.png">
     <link rel="icon" type="image/svg" sizes="32x32" href="{{ site.baseurl }}/img/favicon-32x32.png">

--- a/_includes/hero_contact.html
+++ b/_includes/hero_contact.html
@@ -1,8 +1,9 @@
 <!--Hero Section-->
 <div class="container-fluid  hero-contact-section">
     <!-- Video -->
-    <video class="hero-video" autoplay muted loop playsinline controlslist="nodownload">
+    <video class="hero-video" autoplay muted loop playsinline controlslist="nodownload" preload="none">
         <source src="{{ site.baseurl }}/img/hero_back_play.mp4" type="video/mp4"/>
+        <track kind="captions" label="No dialogue" default>
         Your browser does not support the video tag.
     </video>
 
@@ -11,15 +12,15 @@
     <div class="z-1 container custom-container position-relative py-5">
         <div class="row justify-content-center align-items-start py-5">
             <div class="col-md-6 pt-5">
-                <div class="contact-us py-3"><span class="text-highlight">Contact Us</span></div>
-                <div class="label text-white" style="font-size: 20px; padding-right: 100px;">
+                <h1 class="contact-us py-3 m-0"><span class="text-highlight">Contact Us</span></h1>
+                <p class="label text-white" style="font-size: 20px; padding-right: 100px;">
                     <span class="text-highlight">Connect with our experts to explore tailored solutions for your business challenges. Reach out to our sales team or schedule a demo for the latest insights and updates.</span>
-                </div>
+                </p>
             </div>
             <div class="col-md-6 my-5 position-relative ">
                 <div class="bg-white border border-secondary rounded-3 shadow p-4 text-start text-dark">
                     <div id="contact-heading" class="mb-4 text-left">
-                        <p class="contact-secondary-headline">Get In Touch</p>
+                        <h2 class="contact-secondary-headline m-0">Get In Touch</h2>
                     </div>
                     <form id="contact-form" data-toggle="validator" action="https://app.99inbound.com/api/e/TfLbh_oL"
                           method="POST">

--- a/_includes/jsonld.html
+++ b/_includes/jsonld.html
@@ -1,12 +1,41 @@
 {%- comment -%}
-  JSON-LD structured data:
-  - Organization + WebSite site-wide
-  - Product on product_detail pages
-  - BlogPosting on article pages
+  JSON-LD structured data for Rombo AI site.
+
+  Emits one <script type="application/ld+json"> with a @graph that includes:
+    - Organization (rich)
+    - WebSite
+    - BreadcrumbList (page-aware)
+    - WebPage (page-aware)
+    - Article / BlogPosting (on layout: article)
+    - Product / SoftwareApplication (on layout: products)
+    - Person + ProfilePage (on layout: author)
+
+  Data sources:
+    - site.organization (single source of truth, see _config.yml)
+    - page.* front matter
+    - resolved author (via _includes/author_resolve.html when on article layout)
 {%- endcomment -%}
 
 {%- assign canonical_url = page.url | absolute_url -%}
 {%- assign org_logo = "/img/romboai-04-1-2.png" | absolute_url -%}
+{%- assign org_id = site.url | append: "/#organization" -%}
+{%- assign site_id = site.url | append: "/#website" -%}
+
+{%- comment -%} Build sameAs array from organization config {%- endcomment -%}
+{%- assign same_as = site.organization.same_as | default: empty -%}
+
+{%- comment -%} Author resolution for article pages {%- endcomment -%}
+{%- if page.layout == "article" -%}
+  {%- assign author_obj = nil -%}
+  {% include author_resolve.html author=page.author %}
+{%- endif -%}
+
+{%- comment -%} Last modified date for article pages {%- endcomment -%}
+{%- if page.layout == "article" -%}
+  {%- assign _modified = page.last_modified_at | default: page.dateModified | default: page.date -%}
+{%- else -%}
+  {%- assign _modified = page.last_modified_at | default: page.dateModified -%}
+{%- endif -%}
 
 <script type="application/ld+json">
 {
@@ -14,58 +43,338 @@
   "@graph": [
     {
       "@type": "Organization",
-      "@id": "{{ site.url }}/#organization",
+      "@id": "{{ org_id }}",
       "name": "{{ site.title }}",
+      {%- if site.organization.legal_name %}
+      "legalName": "{{ site.organization.legal_name }}",
+      {%- endif %}
       "url": "{{ site.url }}/",
       "logo": {
         "@type": "ImageObject",
-        "url": "{{ org_logo }}"
+        "url": "{{ org_logo }}",
+        "width": 512,
+        "height": 512
       },
-      "sameAs": [
-        "https://www.linkedin.com/company/rombo-ai/"
-      ]
+      "image": "{{ org_logo }}",
+      "description": "{{ site.description | strip_html | strip_newlines | replace: '"','\"' }}",
+      {%- if site.organization.founding_date %}
+      "foundingDate": "{{ site.organization.founding_date }}",
+      {%- endif %}
+      {%- if site.organization.founding_location %}
+      "foundingLocation": {
+        "@type": "Place",
+        "name": "{{ site.organization.founding_location }}"
+      },
+      {%- endif %}
+      {%- if site.organization.address %}
+      "address": {
+        "@type": "PostalAddress",
+        {%- if site.organization.address.street and site.organization.address.street != "" %}
+        "streetAddress": "{{ site.organization.address.street }}",
+        {%- endif %}
+        {%- if site.organization.address.locality %}
+        "addressLocality": "{{ site.organization.address.locality }}",
+        {%- endif %}
+        {%- if site.organization.address.region %}
+        "addressRegion": "{{ site.organization.address.region }}",
+        {%- endif %}
+        {%- if site.organization.address.postal_code and site.organization.address.postal_code != "" %}
+        "postalCode": "{{ site.organization.address.postal_code }}",
+        {%- endif %}
+        "addressCountry": "{{ site.organization.address.country | default: 'IT' }}"
+      },
+      {%- endif %}
+      {%- if site.organization.geo %}
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": {{ site.organization.geo.latitude }},
+        "longitude": {{ site.organization.geo.longitude }}
+      },
+      {%- endif %}
+      "contactPoint": [
+        {
+          "@type": "ContactPoint",
+          "contactType": "sales",
+          {%- if site.contact_email %}
+          "email": "{{ site.contact_email }}",
+          {%- endif %}
+          {%- if site.contact_phone %}
+          "telephone": "{{ site.contact_phone }}",
+          {%- endif %}
+          "availableLanguage": ["English", "Italian"],
+          "areaServed": {{ site.organization.area_served | default: "Worldwide" | jsonify }}
+        }
+      ],
+      {%- if site.organization.area_served %}
+      "areaServed": {{ site.organization.area_served | jsonify }},
+      {%- endif %}
+      {%- if site.organization.knows_about %}
+      "knowsAbout": {{ site.organization.knows_about | jsonify }},
+      {%- endif %}
+      {%- if site.organization.industry %}
+      "industry": {{ site.organization.industry | jsonify }},
+      {%- endif %}
+      {%- if site.authors and site.authors.size > 0 %}
+      "founder": [
+        {%- assign founders = site.authors | where_exp: "a", "a.job_title contains 'Co-founder'" -%}
+        {%- for a in founders -%}
+        {
+          "@type": "Person",
+          "@id": "{{ a.url | absolute_url }}#person",
+          "name": "{{ a.name }}",
+          "jobTitle": "{{ a.job_title }}",
+          "url": "{{ a.url | absolute_url }}"
+          {%- if a.linkedin and a.linkedin != "" -%}
+          ,"sameAs": ["{{ a.linkedin }}"]
+          {%- endif -%}
+        }{%- unless forloop.last -%},{%- endunless -%}
+        {%- endfor %}
+      ],
+      {%- endif %}
+      "sameAs": {{ same_as | jsonify }}
     },
     {
       "@type": "WebSite",
-      "@id": "{{ site.url }}/#website",
+      "@id": "{{ site_id }}",
       "name": "{{ site.title }}",
       "url": "{{ site.url }}/",
-      "publisher": { "@id": "{{ site.url }}/#organization" }
+      "inLanguage": "{{ site.lang | default: 'en' }}",
+      "publisher": { "@id": "{{ org_id }}" },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "{{ site.url }}/?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      }
+    },
+    {
+      "@type": "WebPage",
+      "@id": "{{ canonical_url }}#webpage",
+      "url": "{{ canonical_url }}",
+      "name": "{{ page.seo_title | default: page.title | default: site.title | replace: '"','\"' }}",
+      "isPartOf": { "@id": "{{ site_id }}" },
+      "inLanguage": "{{ page.lang | default: site.lang | default: 'en' }}",
+      "description": "{{ page.description | default: page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 240 | replace: '"','\"' }}",
+      {%- if _modified %}
+      "dateModified": "{{ _modified | date_to_xmlschema }}",
+      {%- endif %}
+      "primaryImageOfPage": {
+        "@type": "ImageObject",
+        "url": "{{ page.og_image | default: page.image | default: site.og_image | absolute_url }}"
+      },
+      "breadcrumb": { "@id": "{{ canonical_url }}#breadcrumb" }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "{{ canonical_url }}#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "{{ site.url }}/"
+        }
+        {%- if page.url contains "/blog/" and page.url != "/blog/" -%}
+        ,{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Blog",
+          "item": "{{ site.url }}/blog/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "{{ page.title | replace: '"','\"' }}",
+          "item": "{{ canonical_url }}"
+        }
+        {%- elsif page.url contains "/author/" -%}
+        ,{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "About",
+          "item": "{{ site.url }}/about/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "{{ page.name | default: page.title | replace: '"','\"' }}",
+          "item": "{{ canonical_url }}"
+        }
+        {%- elsif page.url != "/" -%}
+        ,{
+          "@type": "ListItem",
+          "position": 2,
+          "name": "{{ page.title | replace: '"','\"' }}",
+          "item": "{{ canonical_url }}"
+        }
+        {%- endif %}
+      ]
     }
+    {%- comment -%}
+    ─────────────────────────────────────────────────────
+    PRODUCT / SOFTWARE APPLICATION (layout: products)
+    ─────────────────────────────────────────────────────
+    {%- endcomment -%}
     {%- if page.layout == "products" -%}
     ,
+    {
+      "@type": "SoftwareApplication",
+      "@id": "{{ canonical_url }}#software",
+      "name": "Material Intelligence Platform",
+      "alternateName": ["NMR AI Analyzer", "Rombo AI Material Intelligence Platform"],
+      "url": "{{ canonical_url }}",
+      "applicationCategory": "BusinessApplication",
+      "applicationSubCategory": "Industrial AI / Spectroscopy Analytics",
+      "operatingSystem": "Web",
+      "description": "{{ page.description | default: page.hero_product_sub_title | default: site.description | strip_html | strip_newlines | truncate: 320 | replace: '"','\"' }}",
+      "brand": { "@id": "{{ org_id }}" },
+      "manufacturer": { "@id": "{{ org_id }}" },
+      "publisher": { "@id": "{{ org_id }}" },
+      "audience": {
+        "@type": "BusinessAudience",
+        "audienceType": "Industrial R&D, QC, Refining, Energy, Petrochemical"
+      },
+      "featureList": [
+        "Benchtop low-field NMR data acquisition and analysis",
+        "AI foundation model pre-trained on millions of quantitative NMR spectra",
+        "Full physio-chemical property estimation in ~15 minutes",
+        "Regime change and drift detection",
+        "AutoML pipeline for custom industrial models",
+        "ASTM / ISO-compliant lab-grade accuracy"
+      ],
+      "keywords": "quantitative NMR, low-field NMR, benchtop NMR, AI, machine learning, crude oil analysis, material intelligence, foundation model"
+    },
     {
       "@type": "Product",
       "@id": "{{ canonical_url }}#product",
       "name": "{{ page.title }}",
-      "brand": { "@type": "Brand", "name": "{{ site.title }}" },
+      "brand": { "@id": "{{ org_id }}" },
+      "manufacturer": { "@id": "{{ org_id }}" },
       "url": "{{ canonical_url }}",
-      "description": "{{ page.description | default: page.hero_product_sub_title | default: site.description | strip_html | strip_newlines | replace: '\"','\\\"' | truncate: 240 }}"
+      "category": "Industrial AI / NMR Analysis",
+      "description": "{{ page.description | default: page.hero_product_sub_title | default: site.description | strip_html | strip_newlines | replace: '"','\"' | truncate: 240 }}",
+      "image": "{{ page.og_image | default: site.og_image | absolute_url }}"
     }
     {%- endif -%}
+    {%- comment -%}
+    ─────────────────────────────────────────────────────
+    ARTICLE / BLOG POSTING (layout: article)
+    ─────────────────────────────────────────────────────
+    {%- endcomment -%}
     {%- if page.layout == "article" -%}
     ,
     {
       "@type": "BlogPosting",
       "@id": "{{ canonical_url }}#blogposting",
-      "headline": "{{ page.title | replace: '\"','\\\"' }}",
+      "isPartOf": { "@id": "{{ site_id }}" },
+      "mainEntityOfPage": { "@id": "{{ canonical_url }}#webpage" },
+      "headline": "{{ page.title | replace: '"','\"' | truncate: 110 }}",
+      "name": "{{ page.title | replace: '"','\"' }}",
+      "description": "{{ page.description | default: page.excerpt | default: site.description | strip_html | strip_newlines | truncate: 240 | replace: '"','\"' }}",
       "datePublished": "{{ page.date | date_to_xmlschema }}",
+      "dateModified": "{{ _modified | date_to_xmlschema }}",
+      "inLanguage": "{{ page.lang | default: site.lang | default: 'en' }}",
       "author": {
+        {%- if author_obj %}
         "@type": "Person",
-        "name": "{{ page.author | default: site.title | replace: '\"','\\\"' }}"
+        "@id": "{{ author_obj.url | absolute_url }}#person",
+        "name": "{{ author_obj.name }}",
+        "url": "{{ author_obj.url | absolute_url }}"
+        {%- if author_obj.job_title -%}
+        ,"jobTitle": "{{ author_obj.job_title }}"
+        {%- endif -%}
+        {%- if author_obj.linkedin and author_obj.linkedin != "" -%}
+        ,"sameAs": ["{{ author_obj.linkedin }}"]
+        {%- endif %}
+        {%- else %}
+        "@type": "Person",
+        "name": "{{ page.author | default: site.title | replace: '"','\"' }}"
+        {%- endif %}
       },
-      "mainEntityOfPage": {
-        "@type": "WebPage",
-        "@id": "{{ canonical_url }}"
-      }
+      "publisher": { "@id": "{{ org_id }}" }
       {%- if page.image -%}
       ,
-      "image": [ "{{ page.image | absolute_url }}" ]
+      "image": {
+        "@type": "ImageObject",
+        "url": "{{ page.image | absolute_url }}",
+        "width": 1200,
+        "height": 630
+      }
       {%- endif -%}
+      {%- if page.tags and page.tags.size > 0 -%}
+      ,"keywords": {{ page.tags | jsonify }}
+      {%- endif -%}
+      {%- if page.categories and page.categories.size > 0 -%}
+      ,"articleSection": {{ page.categories | jsonify }}
+      {%- endif -%}
+    }
+    {%- endif -%}
+    {%- comment -%}
+    ─────────────────────────────────────────────────────
+    PROFILE PAGE / PERSON (layout: author)
+    ─────────────────────────────────────────────────────
+    {%- endcomment -%}
+    {%- if page.layout == "author" -%}
+    ,
+    {
+      "@type": "ProfilePage",
+      "@id": "{{ canonical_url }}#profilepage",
+      "url": "{{ canonical_url }}",
+      "name": "{{ page.name }}",
+      "description": "{{ page.description | default: page.bio | strip_html | strip_newlines | truncate: 240 | replace: '"','\"' }}",
+      "inLanguage": "{{ page.lang | default: site.lang | default: 'en' }}",
+      "mainEntity": { "@id": "{{ canonical_url }}#person" }
+    },
+    {
+      "@type": "Person",
+      "@id": "{{ canonical_url }}#person",
+      "name": "{{ page.name }}",
+      "url": "{{ canonical_url }}",
+      {%- if page.job_title %}
+      "jobTitle": "{{ page.job_title }}",
+      {%- endif %}
+      {%- if page.bio %}
+      "description": "{{ page.bio | strip_html | strip_newlines | replace: '"','\"' | truncate: 480 }}",
+      {%- endif %}
+      {%- if page.image %}
+      "image": "{{ page.image | absolute_url }}",
+      {%- endif %}
+      "worksFor": { "@id": "{{ org_id }}" }
+      {%- if page.expertise and page.expertise.size > 0 -%}
+      ,"knowsAbout": {{ page.expertise | jsonify }}
+      {%- endif -%}
+      {%- if page.linkedin and page.linkedin != "" -%}
+      ,"sameAs": ["{{ page.linkedin }}"]
+      {%- endif -%}
+    }
+    {%- endif -%}
+    {%- comment -%}
+    ─────────────────────────────────────────────────────
+    BLOG LISTING (layout: blog)
+    ─────────────────────────────────────────────────────
+    {%- endcomment -%}
+    {%- if page.layout == "blog" -%}
+    ,
+    {
+      "@type": "Blog",
+      "@id": "{{ canonical_url }}#blog",
+      "url": "{{ canonical_url }}",
+      "name": "Rombo AI Blog",
+      "description": "Perspectives on AI, NMR spectral data, and the future of materials analysis.",
+      "publisher": { "@id": "{{ org_id }}" },
+      "inLanguage": "{{ page.lang | default: site.lang | default: 'en' }}",
+      "blogPost": [
+        {%- for post in site.posts limit:50 -%}
+        {
+          "@type": "BlogPosting",
+          "@id": "{{ post.url | absolute_url }}#blogposting",
+          "url": "{{ post.url | absolute_url }}",
+          "headline": "{{ post.title | replace: '"','\"' | truncate: 110 }}",
+          "datePublished": "{{ post.date | date_to_xmlschema }}"
+        }{%- unless forloop.last -%},{%- endunless -%}
+        {%- endfor %}
+      ]
     }
     {%- endif -%}
   ]
 }
 </script>
-
-

--- a/_includes/privacy.html
+++ b/_includes/privacy.html
@@ -1,6 +1,6 @@
 <div class="container-fluid hero-article-section px-0" style="text-align: left">
     <div class="container custom-container py-5">
-        <h2 class="pt-5 post_header">Privacy Policy</h2>
+        <h1 class="pt-5 post_header">Privacy Policy</h1>
         <p class="span text-dark">Informativa ai sensi dell'art. 13 del Codice della Privacy</p>
         <p><b>Ai sensi dell'articolo 13 del codice della D.Lgs. 196/2003, vi rendiamo le seguenti informazioni.</b></p>
         <p class="span2 text-dark">Noi di <span class="span text-dark"  id="sito">www.rombo.ai</span> riteniamo che la privacy dei nostri visitatori

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -19,7 +19,6 @@
 {% include menu.html %}
 
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 
 
 <!--Hero Section-->
@@ -35,9 +34,9 @@
   <div class="mask"></div>
   <div class="container custom-container pt-5">
       <div class="row m-0 py-5 hero-content-message">
-          <p class="z-1 col-12 align-self-center text-white text-responsive" style="text-align: left">
+          <h1 class="z-1 col-12 align-self-center text-white text-responsive" style="text-align: left">
               <span class="text-highlight">Our Mission and Expertise</span>
-          </p>
+          </h1>
       </div>
       <div class="row p-5 "></div>
   </div>
@@ -61,9 +60,8 @@
   <div class="container custom-container p-3 p-md-5">
       <div class="row">
           <div class="z-1 col-12 py-5 px-4">
-              <div class="z-1 text-wrapper5 text-uppercase" style="color: #001d6c">About Us
-              </div>
-              <div class="z-1 secondary-headline pt-2" style="color: #21272a">Fast, Accurate, AI-Powered NMR Spectral Analysis</div>
+              <p class="z-1 text-wrapper5 text-uppercase m-0" style="color: #001d6c">About Us</p>
+              <h2 class="z-1 secondary-headline pt-2" style="color: #21272a">Fast, Accurate, AI-Powered NMR Spectral Analysis</h2>
           </div>
       </div>
       <div class="row">
@@ -88,7 +86,7 @@
       <!-- Our Vision -->
       <div class="row pt-4">
           <div class="z-1 col-md-12 px-3 px-sm-5">
-              <div class="z-1 secondary-headline pt-2" style="color: #001d6c; font-size: 28px;">Our Vision</div>
+              <h2 class="z-1 secondary-headline pt-2" style="color: #001d6c; font-size: 28px;">Our Vision</h2>
               <div class="hero-label pt-2">
                   <p style="text-align: left;">
                       <span class="span2" style="color: #21272a; z-index: 1">To redefine chemical industrial analysis by making the combination of Artificial Intelligence and NMR seamlessly accessible, enabling businesses worldwide to innovate with precision, speed, and AI confidence.</span>
@@ -100,7 +98,7 @@
       <!-- Our Mission -->
       <div class="row pt-3">
           <div class="z-1 col-md-12 px-3 px-sm-5">
-              <div class="z-1 secondary-headline pt-2" style="color: #001d6c; font-size: 28px;">Our Mission</div>
+              <h2 class="z-1 secondary-headline pt-2" style="color: #001d6c; font-size: 28px;">Our Mission</h2>
               <div class="hero-label pt-2">
                   <p style="text-align: left;">
                       <span class="span2" style="color: #21272a; z-index: 1">We empower medium and large enterprises – especially in energy, oil &amp; gas, biotech, and chemical industries – with fast, precise, and automated molecular characterization and quantification. By combining cutting-edge Low Field NMR spectroscopy with our patented Artificial Intelligence models, we deliver end-to-end automated solutions that reduce manual work, accelerate R&amp;D breakthroughs, and set new standards for efficiency.</span>
@@ -112,7 +110,7 @@
       <!-- Our Values -->
       <div class="row pt-3">
           <div class="z-1 col-md-12 px-3 px-sm-5 pb-5">
-              <div class="z-1 secondary-headline pt-2" style="color: #001d6c; font-size: 28px;">Our Values</div>
+              <h2 class="z-1 secondary-headline pt-2" style="color: #001d6c; font-size: 28px;">Our Values</h2>
               <div class="hero-label pt-3">
                   <div class="row g-3">
                       <div class="col-md-6">

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -19,26 +19,45 @@
 {% include menu_article.html %}
 
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
+{%- assign author_obj = nil -%}
+{% include author_resolve.html author=page.author %}
+{%- assign _modified = page.last_modified_at | default: page.dateModified | default: page.date -%}
 <div class="container-fluid hero-article-section px-0">
   <div class="container custom-container">
       <div class="row m-0 pt-5 w-100 h-100 justify-content-center">
           <div class="col-12 px-4 px-md-5 py-5 align-content-center titolo-1" style="max-width: 895px">
-              <span class="posted_label">
-                  Posted on {{ page.date | date: "%d %B %Y" }}
-                  <br/>
-              </span>
-              <span class="post_header">
-                  {{ page.title }}
-              </span>
+              <nav aria-label="Breadcrumb" class="mb-3">
+                <ol class="breadcrumb" style="font-size:13px;">
+                  <li class="breadcrumb-item"><a href="{{ '/' | relative_url }}" class="text-white-50">Home</a></li>
+                  <li class="breadcrumb-item"><a href="{{ '/blog/' | relative_url }}" class="text-white-50">Blog</a></li>
+                  <li class="breadcrumb-item active text-white" aria-current="page">{{ page.title | truncate: 60 }}</li>
+                </ol>
+              </nav>
+              <p class="posted_label mb-2">
+                  <time datetime="{{ page.date | date_to_xmlschema }}">Posted on {{ page.date | date: "%d %B %Y" }}</time>
+                  {%- if _modified and _modified != page.date %}
+                  &nbsp;·&nbsp;
+                  <time datetime="{{ _modified | date_to_xmlschema }}">Last updated {{ _modified | date: "%d %B %Y" }}</time>
+                  {%- endif %}
+              </p>
+              <h1 class="post_header">{{ page.title }}</h1>
           </div>
       </div>
   </div>
   {% if page.image %}
   <div class="container custom_container">
       <div class="row m-0 p-4 p-md-5">
-          <img src="{{ page.image | relative_url }}" alt="{{ page.image_alt | default: page.title }}" class="m-0 p-0 img-fluid border rounded"
-               style="object-fit: cover">
+          <figure class="m-0 p-0">
+            <img src="{{ page.image | relative_url }}"
+                 alt="{{ page.image_alt | default: page.title }}"
+                 class="m-0 p-0 img-fluid border rounded"
+                 width="1200" height="630"
+                 style="object-fit: cover"
+                 loading="eager" decoding="async">
+            {%- if page.image_caption %}
+            <figcaption class="text-muted mt-2" style="font-size:13px;">{{ page.image_caption }}</figcaption>
+            {%- endif %}
+          </figure>
       </div>
   </div>
   {% endif %}
@@ -54,14 +73,32 @@
   <div class="container custom-container pt-4">
       <div class="row m-0 w-100 h-100 justify-content-center">
           <div class="col-12 px-4 px-md-5 align-content-center titolo-1" style="max-width: 895px">
-
+              {%- if author_obj %}
+              <div class="d-flex align-items-center gap-3 py-3 border-top border-bottom" style="border-color:#eee !important;">
+                {% if author_obj.image %}
+                <img src="{{ author_obj.image | relative_url }}"
+                     alt="Portrait of {{ author_obj.name }}"
+                     width="56" height="56"
+                     class="rounded-circle"
+                     style="object-fit:cover;"
+                     loading="lazy" decoding="async">
+                {% endif %}
+                <div>
+                  <p class="m-0" style="font-size:14px; color:#666; font-style:italic;">Posted by</p>
+                  <p class="m-0">
+                    <a class="andrew-jonson" href="{{ author_obj.url | relative_url }}" rel="author">{{ author_obj.name }}</a>
+                    {%- if author_obj.job_title %}
+                    <span style="color:#666;"> — {{ author_obj.job_title }}</span>
+                    {%- endif %}
+                  </p>
+                </div>
+              </div>
+              {%- else %}
               <p>
-                  <span class="posted_label" style="font-style: italic">
-                  Posted By:
-                  </span>
+                  <span class="posted_label" style="font-style: italic">Posted by:</span>
                   <span class="andrew-jonson pt-3">{{ page.author }}</span>
               </p>
-
+              {%- endif %}
           </div>
       </div>
   </div>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+{% include header.html %}
+<body>
+
+<button id="UpBtn" class="up-btn d-none" aria-label="Back to top">
+  <span>
+    <svg xmlns="http://www.w3.org/2000/svg" width="23.721" height="28.513" viewBox="0 0 28.513 23.721" aria-hidden="true">
+      <g transform="translate(0 0)"><g transform="translate(0 0) rotate(-90)">
+        <path d="M28.057,52.1,17.76,41.8a1.565,1.565,0,0,0-2.207,0l-.935.935a1.549,1.549,0,0,0-.456,1.1,1.58,1.58,0,0,0,.456,1.116l6.007,6.02H1.54A1.523,1.523,0,0,0,0,52.511v1.322a1.581,1.581,0,0,0,1.54,1.6H20.694l-6.075,6.054a1.545,1.545,0,0,0,0,2.191l.935.932a1.565,1.565,0,0,0,2.207,0l10.3-10.3a1.574,1.574,0,0,0,0-2.215Z"
+              transform="translate(-29 -40.346)" fill="#fff"/>
+      </g></g>
+    </svg>
+  </span>
+</button>
+
+{% include menu.html %}
+
+<main id="main-content" tabindex="-1">
+
+<section class="container-fluid py-5" style="background:#FAFAFA; border-bottom:1px solid #E6E6E6;">
+  <div class="container custom_container">
+    <nav aria-label="Breadcrumb" class="mb-3">
+      <ol class="breadcrumb" style="font-size:14px;">
+        <li class="breadcrumb-item"><a href="{{ '/' | relative_url }}">Home</a></li>
+        <li class="breadcrumb-item"><a href="{{ '/about/' | relative_url }}">About</a></li>
+        <li class="breadcrumb-item active" aria-current="page">{{ page.name }}</li>
+      </ol>
+    </nav>
+
+    <div class="row g-4 align-items-center pt-3">
+      {% if page.image %}
+      <div class="col-12 col-md-3 text-center">
+        <img src="{{ page.image | relative_url }}"
+             alt="Portrait of {{ page.name }}"
+             class="img-fluid rounded-circle"
+             style="max-width:180px;"
+             width="180" height="180"
+             loading="lazy" decoding="async">
+      </div>
+      {% endif %}
+      <div class="col-12 col-md-9">
+        <p class="text-uppercase fw-bold mb-1" style="color:#FE900F; letter-spacing:.06em; font-size:13px;">Author</p>
+        <h1 class="fw-bold text-dark" style="font-size:36px;">{{ page.name }}</h1>
+        <p class="text-muted mb-2" style="font-size:18px;">{{ page.job_title }}</p>
+        {% if page.bio %}
+        <p class="text-dark" style="max-width:75ch;">{{ page.bio }}</p>
+        {% endif %}
+
+        {% if page.expertise %}
+        <p class="text-dark mb-1 mt-3 fw-bold">Areas of expertise</p>
+        <ul class="text-dark" style="max-width:75ch;">
+          {% for item in page.expertise %}
+          <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if page.linkedin and page.linkedin != "" %}
+        <p class="mt-3">
+          <a href="{{ page.linkedin }}" rel="noopener noreferrer" target="_blank" aria-label="{{ page.name }} on LinkedIn">LinkedIn profile</a>
+        </p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="container-fluid py-5 bg-white">
+  <div class="container custom_container">
+    <h2 class="fw-bold text-dark mb-4" style="font-size:28px;">Articles by {{ page.name }}</h2>
+    {% assign author_posts = site.posts | where_exp: "p", "p.author contains page.name" %}
+    {% if author_posts.size > 0 %}
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+      {% for post in author_posts %}
+      <div class="col mb-4">
+        <div class="card h-100">
+          <a href="{{ site.baseurl }}{{ post.url }}">
+            {% if post.image %}
+            <img class="post-image"
+                 src="{{ post.image | relative_url }}"
+                 alt="{{ post.image_alt | default: post.title }}"
+                 width="600" height="400" loading="lazy" decoding="async">
+            {% endif %}
+            <div class="post-content">
+              <div class="date">{{ post.date | date: "%b %d, %Y" }}</div>
+              <div class="title">{{ post.title }}</div>
+              <p class="description">{{ post.excerpt | strip_html | truncate: 140 }}</p>
+            </div>
+          </a>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="text-muted">No articles yet from {{ page.name }}.</p>
+    {% endif %}
+  </div>
+</section>
+
+{% include engage.html %}
+{% include footer.html %}
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous" defer></script>
+<script defer src="{{ site.baseurl }}/js/main.js"></script>
+
+<script defer src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js" data-cfasync="false"></script>
+<script>
+  (function() {
+    function initCookieConsent() {
+      if (window.cookieconsent) {
+        window.cookieconsent.initialise({
+          "palette": {
+            "popup": { "background": "#FFFFFF", "text": "#fe900f" },
+            "button": { "background": "#fe900f", "text": "#FFFFFF" }
+          },
+          "content": { "href": "{{ site.baseurl }}/privacy/" }
+        });
+      } else {
+        setTimeout(initCookieConsent, 100);
+      }
+    }
+    initCookieConsent();
+  })();
+</script>
+</body>
+</html>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -19,7 +19,6 @@
 {% include menu.html %}
 
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 
 <!--Hero Section-->
 <div class="container-fluid hero-blog-section px-0">
@@ -32,12 +31,12 @@
   <div class="container h-100 custom-container">
       <div class="row mx-0 w-100 h-100 justify-content-center align-content-center text-center">
           <div class="z-1 col-12 h-100 px-md-4 align-content-center align-items-center titolo-1">
-              <div class="titolo-1-span">
+              <h1 class="titolo-1-span m-0">
                   Welcome to Rombo AI Blog
-              </div>
-              <div class="span2 py-4">
+              </h1>
+              <p class="span2 py-4">
                 Perspectives on AI, NMR Spectral Data, and the Future of Materials Analysis.
-              </div>
+              </p>
           </div>
       </div>
   </div>

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -19,7 +19,6 @@
 {% include menu.html %}
 <!--Hero-->
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 {% include hero_contact.html %}
 {% include hero_divider.html %}
 {% include contact_map.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,6 @@
 {% include menu.html %}
 
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 {{ content }}
 
 <!--Hero Section-->
@@ -35,9 +34,9 @@
   <div class="container custom-container w-100  h-100">
       <div class="row m-0 w-100  h-100  hero-content-message">
           <div class="z-1 col-md-6 align-self-center" style="text-align: left">
-              <div class="text-white text-responsive">
-                  <span class="text-highlight">{{ page.hero_home_title }}</span>
-              </div>
+              <h1 class="text-white text-responsive m-0">
+                  <span class="text-highlight">{{ page.hero_home_title | default: page.title | default: site.title }}</span>
+              </h1>
 
               {% if page.hero_cta_link %}
               <a href="{{ site.baseurl }}{{ page.hero_cta_link }}" class="text-decoration-none d-inline-block mt-4" aria-label="{{ page.hero_cta_label_left | default: 'Contact' }} {{ page.hero_cta_label_right | default: 'now' }}">
@@ -82,11 +81,11 @@
 {% include hero_divider.html %}
 
 <!--Intro Section-->
-<div class="container-fluid py-4">
+<section class="container-fluid py-4" aria-labelledby="intro-heading">
   <div class="row justify-content-center intro-header">
       <div class="col-12">
           <div class="top text-center">
-              <p class="text-wrapper5">{{ page.intro_main_title }}</p>
+              <h2 id="intro-heading" class="text-wrapper5">{{ page.intro_main_title }}</h2>
               <p class="text-wrapper6">{{ page.intro_sub_title }}</p>
           </div>
       </div>
@@ -95,7 +94,7 @@
       <!-- Left Image (Hidden on Mobile) -->
       <div class="col-md-1 d-none d-md-block text-start px-0">
           <img class="img-fluid intro-left" style="padding-right: 21px;" src="{{ site.baseurl }}/img/livello-1-7.svg"
-               alt="Left Level">
+               alt="" aria-hidden="true">
       </div>
 
       <!-- Main Content with Background Image -->
@@ -141,27 +140,27 @@
       <!-- Right Image (Hidden on Mobile) -->
       <div class="col-md-1 d-none d-md-block text-end px-0">
           <img class="img-fluid intro-right" style="padding-left: 21px;" src="{{ site.baseurl }}/img/livello-1-6.svg"
-               alt="Right Level">
+               alt="" aria-hidden="true">
       </div>
   </div>
-</div>
+</section>
 
 <!--Intro Section-->
 
 
 <!--Technology Section-->
-<section class="container-fluid" style="background: #303767;">
+<section class="container-fluid" style="background: #303767;" aria-labelledby="technology-heading">
   <div class="row">
       <div class="col-12 px-0">
           <img class="w-100 m-0 p-0 technology-divider-container" style="bottom:-10px; object-fit: cover"
-               src="{{ site.baseurl }}/img/Separator_Technology.svg" alt="Vector"/>
+               src="{{ site.baseurl }}/img/Separator_Technology.svg" alt="" aria-hidden="true"/>
       </div>
   </div>
   <div class="container custom_container">
       <div class="row">
           <div class="col-12 py-4">
-              <div class="text-wrapper5">{{page.technology_main_title}}</div>
-              <div class="secondary-headline">{{page.technology_sub_title}}</div>
+              <h2 id="technology-heading" class="text-wrapper5">{{page.technology_main_title}}</h2>
+              <p class="secondary-headline">{{page.technology_sub_title}}</p>
           </div>
       </div>
       <div class="row py-4">

--- a/_layouts/default_landing.html
+++ b/_layouts/default_landing.html
@@ -19,7 +19,6 @@
 {% include menu_landing.html %}
 
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 
 {{ content }}
 
@@ -31,19 +30,14 @@
       <track kind="captions" label="No dialogue" default>
       Your browser does not support the video tag.
   </video>
-    <!-- Background Audio -->
-<!--    <audio id="background-audio" autoplay loop style="display: none;">-->
-<!--        <source src="{{ site.baseurl }}/audio/background-audio.mp3" type="audio/mpeg">-->
-<!--        Your browser does not support the audio element.-->
-<!--    </audio>-->
 
   <!-- Mask Overlay -->
   <div class="mask"></div>
   <div class="container custom-container w-100  h-100">
       <div class="row m-0 w-100  h-100  hero-content-message">
-          <p class="z-1 col-md-6 align-self-center text-white text-responsive" style="text-align: left">
+          <h1 class="z-1 col-md-6 align-self-center text-white text-responsive" style="text-align: left">
               <span class="text-highlight">{{ page.hero_home_title }}</span>
-          </p>
+          </h1>
       </div>
   </div>
 </div>
@@ -57,7 +51,7 @@
   <div class="row justify-content-center intro-header">
       <div class="col-12">
           <div class="top text-center">
-              <p class="text-wrapper5">{{ page.intro_main_title }}</p>
+              <h2 class="text-wrapper5">{{ page.intro_main_title }}</h2>
               <p class="text-wrapper6">{{ page.intro_sub_title }}</p>
           </div>
       </div>
@@ -131,8 +125,8 @@
   <div class="container custom_container">
       <div class="row">
           <div class="col-12 py-4">
-              <div class="text-wrapper5 text-uppercase">{{page.technology_main_title}}</div>
-              <div class="secondary-headline">{{page.technology_sub_title}}</div>
+              <h2 class="text-wrapper5 text-uppercase">{{page.technology_main_title}}</h2>
+              <p class="secondary-headline">{{page.technology_sub_title}}</p>
           </div>
       </div>
       <div class="row py-4">

--- a/_layouts/privacy.html
+++ b/_layouts/privacy.html
@@ -18,7 +18,6 @@
 
 {% include menu_article.html %}
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 {% include privacy.html %}
 {% include footer.html %}
 </main>

--- a/_layouts/products.html
+++ b/_layouts/products.html
@@ -19,11 +19,10 @@
 {% include menu.html %}
 
 <main id="main-content" tabindex="-1" class="page-products">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 
 <!-- Hero Section -->
 <div class="container-fluid hero-section">
-  <video class="hero-video" autoplay muted loop playsinline controlslist="nodownload" data-desktop-only="true">
+  <video class="hero-video" autoplay muted loop playsinline controlslist="nodownload" data-desktop-only="true" preload="none">
     <!-- Desktop-only: we set src via JS to prevent mobile from downloading the mp4 -->
     <source data-src="{{ site.baseurl }}/img/hero_back_play.mp4" type="video/mp4"/>
     <track kind="captions" label="No dialogue" default>
@@ -35,13 +34,12 @@
     <div class="row m-0 w-100 h-100">
       <div class="z-1 col-12 col-lg-6 px-3 px-md-4 d-flex align-items-center titolo-1">
         <div class="products-hero-copy">
-          <span class="titolo-1-span text-highlight">
+          <h1 class="titolo-1-span text-highlight m-0" style="display:block;">
             {{ page.hero_product_title }}
-            <br/>
-          </span>
-          <span class="titolo-1-span2 text-highlight">
+          </h1>
+          <p class="titolo-1-span2 text-highlight">
             {{ page.hero_product_sub_title }}
-          </span>
+          </p>
         </div>
       </div>
     </div>

--- a/_layouts/use-cases.html
+++ b/_layouts/use-cases.html
@@ -19,10 +19,9 @@
 {% include menu.html %}
 
 <main id="main-content" tabindex="-1" class="page-products">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 
 <div class="container-fluid hero-section">
-  <video class="hero-video" autoplay muted loop playsinline controlslist="nodownload" data-desktop-only="true">
+  <video class="hero-video" autoplay muted loop playsinline controlslist="nodownload" data-desktop-only="true" preload="none">
     <source data-src="{{ site.baseurl }}/img/hero_back_play.mp4" type="video/mp4"/>
     <track kind="captions" label="No dialogue" default>
     Your browser does not support the video tag.
@@ -33,13 +32,12 @@
     <div class="row m-0 w-100 h-100">
       <div class="z-1 col-12 col-lg-8 px-3 px-md-4 d-flex align-items-center titolo-1">
         <div class="products-hero-copy">
-          <span class="titolo-1-span text-highlight">
+          <h1 class="titolo-1-span text-highlight m-0" style="display:block;">
             {{ page.hero_title }}
-            <br/>
-          </span>
-          <span class="titolo-1-span2 text-highlight">
+          </h1>
+          <p class="titolo-1-span2 text-highlight">
             {{ page.hero_subtitle }}
-          </span>
+          </p>
         </div>
       </div>
     </div>

--- a/_layouts/voucher.html
+++ b/_layouts/voucher.html
@@ -18,7 +18,6 @@
 
 {% include menu_article.html %}
 <main id="main-content" tabindex="-1">
-  <h1 class="visually-hidden">{{ page.h1 | default: page.title | default: site.title }}</h1>
 {% include voucher_info.html %}
 {% include footer.html %}
 </main>

--- a/_posts/2024-12-09-machine-learning-for-rd.md
+++ b/_posts/2024-12-09-machine-learning-for-rd.md
@@ -48,6 +48,6 @@ markdown_content: |
   - **Process Optimization**: Rapid identification of key parameters to improve operational efficiency and reduce waste.
   - **Predictive Analysis**: Accurate prediction of chemical properties from spectroscopic data, thereby improving data-driven decision-making. 
 
-author: "Raffaele Taglialatela"
+author: "Silvia Bongiovanni"
 excerpt: "SpectraML breaks down barriers to Machine Learning adoption with its low-code/no-code approach. Designed for R&D teams, it simplifies data preparation, model training, and deployment—enabling faster innovation and the creation of custom solutions tailored to your needs."
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -11150,10 +11150,13 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/js-sha1": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "mermaid": "11.12.2",
     "vite": "6.4.1",
     "@vitejs/plugin-react": "5.1.2",
-    "esbuild": "0.27.2"
+    "esbuild": "0.27.2",
+    "js-cookie": "3.0.7"
   },
   "pnpm": {
     "overrides": {
@@ -49,7 +50,8 @@
       "mermaid": "11.12.2",
       "vite": "6.4.1",
       "@vitejs/plugin-react": "5.1.2",
-      "esbuild": "0.27.2"
+      "esbuild": "0.27.2",
+      "js-cookie": "3.0.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   vite: 6.4.1
   '@vitejs/plugin-react': 5.1.2
   esbuild: 0.27.2
+  js-cookie: 3.0.7
 
 importers:
 
@@ -19,6 +20,9 @@ importers:
       '@uiw/react-md-editor':
         specifier: ^4.0.11
         version: 4.0.11(@types/react@19.2.7)(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
+      d3-sankey:
+        specifier: ^0.12.3
+        version: 0.12.3
       is-hotkey:
         specifier: ^0.2.0
         version: 0.2.0
@@ -426,8 +430,8 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
-  '@graphql-codegen/plugin-helpers@6.1.0':
-    resolution: {integrity: sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==}
+  '@graphql-codegen/plugin-helpers@7.0.1':
+    resolution: {integrity: sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==}
     engines: {node: '>=16'}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -514,6 +518,12 @@ packages:
 
   '@graphql-tools/utils@10.11.0':
     resolution: {integrity: sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@11.1.0':
+    resolution: {integrity: sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -2046,8 +2056,14 @@ packages:
   change-case-all@1.0.15:
     resolution: {integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==}
 
+  change-case-all@2.1.0:
+    resolution: {integrity: sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==}
+
   change-case@4.1.2:
     resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -3098,8 +3114,9 @@ packages:
       react:
         optional: true
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-sha1@0.6.0:
     resolution: {integrity: sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w==}
@@ -4483,6 +4500,9 @@ packages:
   sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
 
+  sponge-case@2.0.3:
+    resolution: {integrity: sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -4561,6 +4581,9 @@ packages:
 
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
+
+  swap-case@3.0.3:
+    resolution: {integrity: sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==}
 
   tabbable@6.3.0:
     resolution: {integrity: sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==}
@@ -5421,15 +5444,14 @@ snapshots:
       lodash: 4.17.21
       tslib: 2.6.2
 
-  '@graphql-codegen/plugin-helpers@6.1.0(graphql@15.8.0)':
+  '@graphql-codegen/plugin-helpers@7.0.1(graphql@15.8.0)':
     dependencies:
-      '@graphql-tools/utils': 10.11.0(graphql@15.8.0)
-      change-case-all: 1.0.15
+      '@graphql-tools/utils': 11.1.0(graphql@15.8.0)
+      change-case-all: 2.1.0
       common-tags: 1.8.2
       graphql: 15.8.0
       import-from: 4.0.0
-      lodash: 4.17.21
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@graphql-codegen/schema-ast@4.1.0(graphql@15.8.0)':
     dependencies:
@@ -5559,6 +5581,14 @@ snapshots:
       value-or-promise: 1.0.12
 
   '@graphql-tools/utils@10.11.0(graphql@15.8.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 15.8.0
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@11.1.0(graphql@15.8.0)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       '@whatwg-node/promise-helpers': 1.3.2
@@ -6445,7 +6475,7 @@ snapshots:
   '@tinacms/cli@2.0.5(@codemirror/language@6.0.0)(@types/node@25.0.3)(@types/react@19.2.7)(abstract-level@1.0.4)(immer@10.2.0)(jiti@1.21.7)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/node@25.0.3)(@types/react@19.2.7)(react@19.0.0-rc-fb9a90fa48-20240614))(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)(rollup@4.54.0)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.1)(use-sync-external-store@1.6.0(react@19.0.0-rc-fb9a90fa48-20240614))(yaml@2.8.2)':
     dependencies:
       '@graphql-codegen/core': 2.6.8(graphql@15.8.0)
-      '@graphql-codegen/plugin-helpers': 6.1.0(graphql@15.8.0)
+      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@15.8.0)
       '@graphql-codegen/typescript': 4.1.6(graphql@15.8.0)
       '@graphql-codegen/typescript-operations': 4.6.1(graphql@15.8.0)
       '@graphql-codegen/visitor-plugin-common': 4.1.2(graphql@15.8.0)
@@ -7383,6 +7413,13 @@ snapshots:
       upper-case: 2.0.2
       upper-case-first: 2.0.2
 
+  change-case-all@2.1.0:
+    dependencies:
+      change-case: 5.4.4
+      sponge-case: 2.0.3
+      swap-case: 3.0.3
+      title-case: 3.0.3
+
   change-case@4.1.2:
     dependencies:
       camel-case: 4.1.2
@@ -7397,6 +7434,8 @@ snapshots:
       sentence-case: 3.0.4
       snake-case: 3.0.4
       tslib: 2.8.1
+
+  change-case@5.4.4: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -8551,7 +8590,7 @@ snapshots:
       '@types/react': 19.2.7
       react: 19.0.0-rc-fb9a90fa48-20240614
 
-  js-cookie@2.2.1: {}
+  js-cookie@3.0.7: {}
 
   js-sha1@0.6.0: {}
 
@@ -10086,7 +10125,7 @@ snapshots:
       copy-to-clipboard: 3.3.3
       fast-deep-equal: 3.1.3
       fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
+      js-cookie: 3.0.7
       nano-css: 5.6.2(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
       react: 19.0.0-rc-fb9a90fa48-20240614
       react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614)
@@ -10587,6 +10626,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  sponge-case@2.0.3: {}
+
   sprintf-js@1.0.3: {}
 
   sqlite-level@1.2.1(sucrase@3.35.1):
@@ -10670,6 +10711,8 @@ snapshots:
   swap-case@2.0.2:
     dependencies:
       tslib: 2.8.1
+
+  swap-case@3.0.3: {}
 
   tabbable@6.3.0: {}
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,152 @@
+# Rombo AI - robots.txt
+# Last updated: 2026-05
+# Policy: allow indexing for search and AI-search systems; allow LLM training crawlers
+# by default, with named blocks for granular control. Adjust per business decision.
+
+# ─────────────────────────────────────────────────────────────
+# DEFAULT — all user agents
+# ─────────────────────────────────────────────────────────────
 User-agent: *
 Allow: /
+Disallow: /admin/
+Disallow: /tina/
+Disallow: /e2e/
+Disallow: /tests/
+Disallow: /scripts/
+Disallow: /vendor/
+Disallow: /.idea/
+Disallow: /.jekyll-cache/
+Disallow: /.sass-cache/
 
+# ─────────────────────────────────────────────────────────────
+# MAJOR SEARCH ENGINES — explicit allow
+# ─────────────────────────────────────────────────────────────
+User-agent: Googlebot
+Allow: /
+
+User-agent: Googlebot-Image
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+# ─────────────────────────────────────────────────────────────
+# AI SEARCH (answer engines that show citations)
+# These should be ALLOWED to maximize discoverability in LLM answers.
+# ─────────────────────────────────────────────────────────────
+
+# OpenAI ChatGPT Search (required to appear in ChatGPT Search results)
+User-agent: OAI-SearchBot
+Allow: /
+
+# OpenAI ChatGPT user actions (Atlas / Agent / browse on demand)
+User-agent: ChatGPT-User
+Allow: /
+
+# Perplexity answer engine (live retrieval, shows citations)
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# Microsoft Copilot / Bing AI Chat (uses Bingbot index + dedicated crawlers)
+User-agent: BingPreview
+Allow: /
+
+# You.com search assistant
+User-agent: YouBot
+Allow: /
+
+# Anthropic Claude live search (web fetch on demand)
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+# ─────────────────────────────────────────────────────────────
+# AI TRAINING CRAWLERS — business decision
+# Currently ALLOWED to maximize presence in future model knowledge.
+# To opt-out of any single one, change "Allow: /" to "Disallow: /".
+# ─────────────────────────────────────────────────────────────
+
+# OpenAI training crawler
+User-agent: GPTBot
+Allow: /
+
+# Google Gemini / Vertex AI training (independent from Googlebot index)
+User-agent: Google-Extended
+Allow: /
+
+# Anthropic Claude training
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+# Apple Intelligence training (independent from Applebot)
+User-agent: Applebot-Extended
+Allow: /
+
+# Meta AI training
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+# Common Crawl (used as training source by many LLMs)
+User-agent: CCBot
+Allow: /
+
+# Amazon AI / Alexa
+User-agent: Amazonbot
+Allow: /
+
+# Cohere
+User-agent: cohere-ai
+Allow: /
+
+User-agent: cohere-training-data-crawler
+Allow: /
+
+# Mistral AI
+User-agent: MistralAI-User
+Allow: /
+
+# ─────────────────────────────────────────────────────────────
+# SCRAPERS / LOW-VALUE BOTS — disallow
+# ─────────────────────────────────────────────────────────────
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: omgilibot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+User-agent: Timpibot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+# ─────────────────────────────────────────────────────────────
+# SITEMAP
+# ─────────────────────────────────────────────────────────────
 Sitemap: https://rombo.ai/sitemap.xml
-
-

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,16 +1,23 @@
 ---
 layout: null
 permalink: /sitemap.xml
+sitemap: false
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/0.9">
+
+  {%- comment -%} Build time as fallback "lastmod" for static pages {%- endcomment -%}
+  {%- assign build_time = site.time | date_to_xmlschema -%}
+
   <url>
     <loc>{{ "/" | absolute_url }}</loc>
-    <changefreq>weekly</changefreq>
+    <lastmod>{{ build_time }}</lastmod>
     <priority>1.0</priority>
   </url>
 
-  {%- comment -%} Collection pages in _pages/ {%- endcomment -%}
+  {%- comment -%} Collection pages (_pages/) {%- endcomment -%}
   {%- assign pages_collection = site.collections["pages"] -%}
   {%- if pages_collection and pages_collection.docs -%}
   {%- for p in pages_collection.docs -%}
@@ -20,15 +27,16 @@ permalink: /sitemap.xml
     {%- if p.url == "/" -%}{%- continue -%}{%- endif -%}
     {%- if p.url contains "/admin" -%}{%- continue -%}{%- endif -%}
     {%- if p.url contains "/e2e/" -%}{%- continue -%}{%- endif -%}
+    {%- assign lastmod = p.last_modified_at | default: p.dateModified | default: build_time -%}
     <url>
       <loc>{{ p.url | absolute_url }}</loc>
-      <changefreq>monthly</changefreq>
-      <priority>0.7</priority>
+      <lastmod>{{ lastmod | date_to_xmlschema }}</lastmod>
+      <priority>0.8</priority>
     </url>
   {%- endfor -%}
   {%- endif -%}
 
-  {%- comment -%} Any other pages (non-collection) {%- endcomment -%}
+  {%- comment -%} Standalone pages (not in collections) {%- endcomment -%}
   {%- for p in site.pages -%}
     {%- assign robots = p.robots | default: "index,follow" -%}
     {%- if p.sitemap == false -%}{%- continue -%}{%- endif -%}
@@ -37,25 +45,51 @@ permalink: /sitemap.xml
     {%- if p.url contains "/admin" -%}{%- continue -%}{%- endif -%}
     {%- if p.url contains "/e2e/" -%}{%- continue -%}{%- endif -%}
     {%- if p.url == "/sitemap.xml" -%}{%- continue -%}{%- endif -%}
+    {%- if p.url == "/robots.txt" -%}{%- continue -%}{%- endif -%}
+    {%- if p.url contains ".xml" -%}{%- continue -%}{%- endif -%}
+    {%- if p.url contains ".txt" -%}{%- continue -%}{%- endif -%}
+    {%- assign lastmod = p.last_modified_at | default: p.dateModified | default: build_time -%}
     <url>
       <loc>{{ p.url | absolute_url }}</loc>
-      <changefreq>monthly</changefreq>
+      <lastmod>{{ lastmod | date_to_xmlschema }}</lastmod>
       <priority>0.5</priority>
     </url>
   {%- endfor -%}
+
+  {%- comment -%} Author profile pages {%- endcomment -%}
+  {%- if site.authors -%}
+  {%- for a in site.authors -%}
+    {%- assign robots = a.robots | default: "index,follow" -%}
+    {%- if a.sitemap == false -%}{%- continue -%}{%- endif -%}
+    {%- if robots contains "noindex" -%}{%- continue -%}{%- endif -%}
+    {%- assign lastmod = a.last_modified_at | default: build_time -%}
+    <url>
+      <loc>{{ a.url | absolute_url }}</loc>
+      <lastmod>{{ lastmod | date_to_xmlschema }}</lastmod>
+      <priority>0.6</priority>
+    </url>
+  {%- endfor -%}
+  {%- endif -%}
 
   {%- comment -%} Blog posts {%- endcomment -%}
   {%- for post in site.posts -%}
     {%- assign robots = post.robots | default: "index,follow" -%}
     {%- if post.sitemap == false -%}{%- continue -%}{%- endif -%}
     {%- if robots contains "noindex" -%}{%- continue -%}{%- endif -%}
+    {%- assign lastmod = post.last_modified_at | default: post.dateModified | default: post.date -%}
     <url>
       <loc>{{ post.url | absolute_url }}</loc>
-      <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
-      <changefreq>yearly</changefreq>
-      <priority>0.6</priority>
+      <lastmod>{{ lastmod | date_to_xmlschema }}</lastmod>
+      <priority>0.7</priority>
+      {%- if post.image %}
+      <image:image>
+        <image:loc>{{ post.image | absolute_url }}</image:loc>
+        <image:title>{{ post.title | xml_escape }}</image:title>
+        {%- if post.image_alt %}
+        <image:caption>{{ post.image_alt | xml_escape }}</image:caption>
+        {%- endif %}
+      </image:image>
+      {%- endif %}
     </url>
   {%- endfor -%}
 </urlset>
-
-


### PR DESCRIPTION
Improve discoverability in AI-driven search surfaces (Google AI Overviews, ChatGPT Search, Perplexity, Copilot) and traditional SEO with a coordinated set of changes across crawler policy, structured data, semantic markup, authorship, freshness signals, and AI referral tracking.

Crawler policy
- Rewrite robots.txt with explicit allow/disallow for ~25 user agents: search (Googlebot, Bingbot, DuckDuckBot, Applebot), AI search (OAI-SearchBot, ChatGPT-User, PerplexityBot, Claude-SearchBot, YouBot), AI training (GPTBot, Google-Extended, ClaudeBot, Applebot-Extended, Meta-ExternalAgent, CCBot, Amazonbot, MistralAI-User), scrapers blocked (Bytespider, Diffbot, omgili, PetalBot).

Structured data
- Centralize organization data in _config.yml (legal_name, founding_date, address, geo, area_served, knows_about, industry, same_as).
- Expand JSON-LD into a coherent @graph with Organization (founder array, contactPoint, knowsAbout), WebSite (SearchAction), WebPage (dateModified), BreadcrumbList (page-aware), BlogPosting (author Person, publisher, keywords, image with dimensions), SoftwareApplication + Product on /product/, ProfilePage + Person on author pages, Blog on /blog/.

Authorship
- Add _authors collection with andrea-zanda, carmine-mattia, silvia-bongiovanni.
- New _layouts/author.html with breadcrumb, filtered article list and ProfilePage schema.
- _includes/author_resolve.html maps page.author string to author doc.
- Article by-line links to /author/<slug>/ with avatar and rel=author.
- Update SpectraML post author to Silvia Bongiovanni.

Freshness
- Support last_modified_at on posts and pages; show "Last updated" in article hero when different from publish date.
- Propagate dateModified into BlogPosting and WebPage JSON-LD.
- sitemap.xml uses real <lastmod> per URL, adds image:image entries and author pages section.

Meta and head
- Robots default to "index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" to unlock rich previews.
- Add article:published_time, article:modified_time, article:author, article:tag, article:section, og:image:width/height/alt, meta name="author", twitter:image:alt, og:type=profile on author pages.

Semantic HTML / heading hierarchy
- Remove duplicate visually-hidden h1s across layouts.
- Promote hero titles to a single semantic h1 on home, products, use-cases, blog, about, contact, privacy, default_landing.
- Promote section titles from div/span/p to h2 (intro, technology, Our Vision/Mission/Values, Get In Touch).
- Convert blog list to <ul>/<li>/<article> with h3 card titles and <time datetime>.
- Decorative images get alt="" and aria-hidden="true".
- preload="none" on hero <video> elements.

Discoverability extras
- New 404.html (noindex,follow) with cards to all main sections.
- Enable kramdown auto_ids for anchor links on markdown headings.

GA4 AI referral tracking
- Detect 12+ AI assistant hosts (chatgpt, perplexity, gemini, copilot, claude, you.com, meta.ai, mistral, ...) + utm fallback.
- Emit GA4 event ai_assistant_referral with ai_source param and set user_property ai_referrer so a custom Channel Group "AI Assistants" can be configured in GA4.

Security
- Add overrides for js-cookie 3.0.7 in package.json (npm + pnpm) to fix GHSA-qjx8-664m-686j (Per-instance prototype hijack in assign() enables cookie-attribute injection); pulled transitively by react-use via tinacms.